### PR TITLE
Add resource pack upload button

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,6 +124,8 @@
                         <input type="text" id="user" placeholder="Username" class="text">
                         <label class="password" id="password">Password</label>
                         <input type="text" placeholder="Password" id="pass" class="text" disabled>
+                        <input type="button" value="Upload Pack" id="resourcePackButton" onclick='uploadResourcePack()'>
+                        <span id="resourcePackStatus"></span>
                         <input type="button" value="Play" id="launchButton" onclick='launch()'>
                     </div>
                         </div>

--- a/js/auth.js
+++ b/js/auth.js
@@ -1,6 +1,56 @@
 var pass = document.getElementById('pass');
 var t = document.getElementById('type');
 var v = document.getElementById('version');
+var resourcePackStatus = document.getElementById('resourcePackStatus');
+var electronRemote = require('electron').remote;
+var fs = require('fs');
+var os = require('os');
+var path = require('path');
+
+function getMinecraftDirectory() {
+    if (process.platform === 'win32') {
+        return path.join(process.env.APPDATA || path.join(os.homedir(), 'AppData', 'Roaming'), '.minecraft');
+    }
+
+    if (process.platform === 'darwin') {
+        return path.join(os.homedir(), 'Library', 'Application Support', 'minecraft');
+    }
+
+    return path.join(os.homedir(), '.minecraft');
+}
+
+function setResourcePackStatus(message, error) {
+    resourcePackStatus.textContent = message;
+    resourcePackStatus.className = error ? 'resource-pack-error' : 'resource-pack-success';
+}
+
+async function uploadResourcePack() {
+    var result = await electronRemote.dialog.showOpenDialog(electronRemote.getCurrentWindow(), {
+        title: 'Select Minecraft Resource Pack',
+        buttonLabel: 'Upload Pack',
+        properties: ['openFile'],
+        filters: [
+            { name: 'Minecraft Resource Packs', extensions: ['zip'] }
+        ]
+    });
+
+    if (result.canceled || !result.filePaths.length) {
+        return;
+    }
+
+    var sourcePath = result.filePaths[0];
+    var destinationDirectory = path.join(getMinecraftDirectory(), 'resourcepacks');
+    var destinationPath = path.join(destinationDirectory, path.basename(sourcePath));
+
+    try {
+        fs.mkdirSync(destinationDirectory, { recursive: true });
+        fs.copyFileSync(sourcePath, destinationPath);
+        setResourcePackStatus('Pack uploaded to resourcepacks.', false);
+    } catch (error) {
+        setResourcePackStatus('Could not upload pack: ' + error.message, true);
+    }
+}
+
 var change = (type) => {
     pass.disabled = type == 0
 }
@@ -19,7 +69,7 @@ function launch() {
                 version: v.options[v.selectedIndex].value
             }
             window.launch(JSON.stringify(op));
-            ['launchButton', 'user', 'pass', 'type', 'version'].forEach((id) => {
+            ['launchButton', 'resourcePackButton', 'user', 'pass', 'type', 'version'].forEach((id) => {
                 document.getElementById(id).disabled = true;
             });
         }
@@ -31,10 +81,15 @@ function log(log) {
 }
 
 function logError(string) {
-    ['launchButton', 'user', 'pass', 'type', 'version'].forEach((id) => {
+    ['launchButton', 'resourcePackButton', 'user', 'pass', 'type', 'version'].forEach((id) => {
         document.getElementById(id).disabled = false;
     });
-    document.getElementById('log').innerHTML += `<p class="error">${string}</p><br>`;
+    var logElement = document.getElementById('log');
+    if (logElement) {
+        logElement.innerHTML += `<p class="error">${string}</p><br>`;
+    } else {
+        setResourcePackStatus(string, true);
+    }
 }
 
 var getVersions = (str) => {

--- a/styles.css
+++ b/styles.css
@@ -1398,6 +1398,41 @@ body {
     border-color: transparent;
 }
 
+#resourcePackButton {
+    padding: 7px;
+    margin-left: 10px;
+    font-size: 13px;
+    font-family: 'bloxatregular';
+    background-color: transparent;
+    color: white;
+    border-color: transparent;
+}
+
+#resourcePackButton:hover,
+#resourcePackButton:focus {
+    text-shadow: 0px 0px 20px #fff;
+    outline: none;
+    transition: 0.2s ease-in-out;
+}
+
+#resourcePackStatus {
+    display: inline-block;
+    max-width: 160px;
+    margin-left: 8px;
+    font-family: 'Alata', sans-serif;
+    font-size: 11px;
+    line-height: 1.2;
+    vertical-align: middle;
+}
+
+.resource-pack-success {
+    color: greenyellow;
+}
+
+.resource-pack-error {
+    color: red;
+}
+
 #launchButton:hover,
 #launchButton:focus {
 


### PR DESCRIPTION
Closes #7.\n\nThis adds a small launcher-side resource pack upload flow:\n\n- adds an Upload Pack button next to Play\n- lets the user select a .zip resource pack\n- creates the Minecraft resourcepacks directory when needed\n- copies the selected pack into the platform-specific Minecraft resourcepacks folder\n- shows success/error status in the launcher UI\n\nValidation:\n- node --check js/auth.js\n- node --check main.js\n- node --check index.js\n- git diff --check